### PR TITLE
Disable `require` for CUDA-related libraries in “test.lua”.

### DIFF
--- a/test.lua
+++ b/test.lua
@@ -7,8 +7,6 @@
 
 require 'torch'
 require 'nn'
-require 'cunn'
-require 'cudnn'
 
 local tnt = require 'torchnet'
 local xlua = require 'xlua'


### PR DESCRIPTION
These are already loaded conditionally, if we are using GPU, i.e. running with `-gpu N` for N > 0.