### PR TITLE
Fix: Add src/common/Utils-base.cc to CMakeLists.txt

### DIFF
--- a/src/common/CMakeLists.txt
+++ b/src/common/CMakeLists.txt
@@ -11,6 +11,7 @@ target_sources(
   ${CMAKE_CURRENT_SOURCE_DIR}/Dictionary.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/Transforms.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/Utils.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/Utils-base.cpp
   )
 
 target_link_libraries(


### PR DESCRIPTION
The recent commit with the OnlineDecoder added `src/common/Utils-base.cc`, but didn't add it to the target sources in `src/common/CMakeLists.txt`. Due to this, builds are failing for me when linking.