### PR TITLE
Add Residual.cpp to CMakeLists

### DIFF
--- a/src/module/CMakeLists.txt
+++ b/src/module/CMakeLists.txt
@@ -8,6 +8,7 @@ add_library(
 target_sources(
   module
   INTERFACE
+  ${CMAKE_CURRENT_SOURCE_DIR}/Residual.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/W2lModule.cpp
   )
 


### PR DESCRIPTION
- Fixes build error (Residual.cpp is excluded from the CMakeLists, but the module is registered for CEREAL in Residual.h)