### PR TITLE
Update Test.cpp to make "sample" numbers in output consistent with Decode

### DIFF
--- a/Test.cpp
+++ b/Test.cpp
@@ -114,6 +114,7 @@ int main(int argc, char** argv) {
     auto emission = afToVector<float>(rawEmission);
     auto ltrTarget = afToVector<int>(sample[kTargetIdx]);
     auto wrdTarget = afToVector<int>(sample[kWordIdx]);
+    auto sampleId = afToVector<std::string>(sample[kFileIdIdx]).front();
 
     /* viterbiPath + remove duplication/blank */
     auto viterbiPath =
@@ -146,7 +147,7 @@ int main(int argc, char** argv) {
       std::cout << "|T|: " << tensor2letters(ltrTarget, tokenDict) << std::endl;
       std::cout << "|P|: " << tensor2letters(viterbiPath, tokenDict)
                 << std::endl;
-      std::cout << "[sample: " << cnt << ", WER: " << meters.wer.value()[0]
+      std::cout << "[sample: " << sampleId << ", WER: " << meters.wer.value()[0]
                 << "\%, LER: " << meters.ler.value()[0]
                 << "\%, total WER: " << meters.werSlice.value()[0]
                 << "\%, total LER: " << meters.lerSlice.value()[0]


### PR DESCRIPTION
Test.cpp produces predictions of characters without the LM. 
Without the proposed change, the sample numbers in the output just progress from 1 to n (where n is the number of files in the test set). This is inconsistent with the Decode ouput which lists sample number.
The proposed change make the "sample" output consistent with the Decode output. This is useful if you want to see where the language model is modifying the predictions of the Acoustic model