### PR TITLE
Throw error if no train examples found and readme improvement

### DIFF
--- a/docs/train.md
+++ b/docs/train.md
@@ -17,8 +17,8 @@ command line:
 --archdir <path/to/architecture/files/> \
 --rundir <path/to/save/models/> \
 --arch   <name_of_architecture.arch> \
---train  <train/datasets/> \
---valid  <validation/datasets> \
+--train  <train/datasets/ds1.lst,train/datasets/ds2.lst> \
+--valid  <validation/datasets/ds1.lst,validation/datasets/ds2.lst> \
 --lexicon <path/to/lexicon.txt> \
 --lr=0.0001 \
 --lrcrit=0.0001
@@ -43,7 +43,7 @@ complete list of the flag definitions and short descriptions of their meaning
 can be found [here](../src/common/Defines.cpp).
 
 The `datadir` flag is the base path to where all the `train` and `valid`
-dataset directories live. Every `train` path will be prefixed by `datadir`.
+dataset list files live. Every `train` path will be prefixed by `datadir`.
 Multiple datasets can be passed to `train` and `valid` as a comma-separated
 list. More details on dataset preparation can be found [here](data_prep.md).
 

--- a/src/data/W2lListFilesDataset.cpp
+++ b/src/data/W2lListFilesDataset.cpp
@@ -134,6 +134,10 @@ std::vector<SpeechSampleMetaInfo> W2lListFilesDataset::loadListFile(
     ++idx;
   }
 
+  if (samplesMetaInfo.size() < 1) {
+    throw std::runtime_error("Train files not found from " + filename);
+  }
+
   LOG(INFO) << samplesMetaInfo.size() << " files found. ";
 
   return samplesMetaInfo;


### PR DESCRIPTION
Hello! Thank you for excellent library! 

When I was running train flow for the first time according to examples from https://github.com/facebookresearch/wav2letter/blob/master/docs/train.md - everything was looking fine, everything started, in logs as well everything was good at the start - arch loaded, nothing failed. And I left it to train for a night. I was surprised in the morning when I found out (reading source code) that I failed to provide list file path and provided directory path in `--train` flag, and it was silently ignored. My model trained whole night with 0 examples; it did 20k+ epochs successfully with zero loss and everything.

I want to change README a bit and to throw an error if no examples found.