### PR TITLE
s/CMAKE_SOURCE_DIR/PROJECT_SOURCE_DIR/

### DIFF
--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -18,28 +18,28 @@ function(build_test SRCFILE)
   target_include_directories(
     ${target}
     PRIVATE
-    ${CMAKE_SOURCE_DIR}/..
+    ${PROJECT_SOURCE_DIR}/..
     ${GTEST_INCLUDE_DIR}
     ${GMOCK_INCLUDE_DIR}
     )
   target_compile_definitions(
     ${target}
     PRIVATE
-    "DATA_TEST_DATADIR=\"${CMAKE_SOURCE_DIR}/src/data/test/testdata\""
-    "DECODER_TEST_DATADIR=\"${CMAKE_SOURCE_DIR}/src/decoder/test\""
-    "FEATURE_TEST_DATADIR=\"${CMAKE_SOURCE_DIR}/src/feature/test/data\""
-    "MODULE_TEST_ARCHDIR=\"${CMAKE_SOURCE_DIR}/src/module/test\""
+    "DATA_TEST_DATADIR=\"${PROJECT_SOURCE_DIR}/src/data/test/testdata\""
+    "DECODER_TEST_DATADIR=\"${PROJECT_SOURCE_DIR}/src/decoder/test\""
+    "FEATURE_TEST_DATADIR=\"${PROJECT_SOURCE_DIR}/src/feature/test/data\""
+    "MODULE_TEST_ARCHDIR=\"${PROJECT_SOURCE_DIR}/src/module/test\""
     )
   add_test(${target} ${target})
 endfunction(build_test)
 
 if (W2L_BUILD_TESTS)
   # Common
-  build_test(${CMAKE_SOURCE_DIR}/src/common/test/W2lCommonTest.cpp)
-  build_test(${CMAKE_SOURCE_DIR}/src/common/test/DictionaryTest.cpp)
+  build_test(${PROJECT_SOURCE_DIR}/src/common/test/W2lCommonTest.cpp)
+  build_test(${PROJECT_SOURCE_DIR}/src/common/test/DictionaryTest.cpp)
   set(
     W2L_DICTIONARY_TEST_DIR
-    "\"${CMAKE_SOURCE_DIR}/src/common/test/\""
+    "\"${PROJECT_SOURCE_DIR}/src/common/test/\""
     )
   target_compile_definitions(
     DictionaryTest
@@ -48,28 +48,28 @@ if (W2L_BUILD_TESTS)
   )
 
   # Criterion
-  build_test(${CMAKE_SOURCE_DIR}/src/criterion/test/CriterionTest.cpp)
-  build_test(${CMAKE_SOURCE_DIR}/src/criterion/test/Seq2SeqTest.cpp)
-  build_test(${CMAKE_SOURCE_DIR}/src/criterion/attention/test/AttentionTest.cpp)
-  build_test(${CMAKE_SOURCE_DIR}/src/criterion/attention/test/WindowTest.cpp)
+  build_test(${PROJECT_SOURCE_DIR}/src/criterion/test/CriterionTest.cpp)
+  build_test(${PROJECT_SOURCE_DIR}/src/criterion/test/Seq2SeqTest.cpp)
+  build_test(${PROJECT_SOURCE_DIR}/src/criterion/attention/test/AttentionTest.cpp)
+  build_test(${PROJECT_SOURCE_DIR}/src/criterion/attention/test/WindowTest.cpp)
   # Data
-  build_test(${CMAKE_SOURCE_DIR}/src/data/test/DataTest.cpp)
-  build_test(${CMAKE_SOURCE_DIR}/src/data/test/ListFileDatasetTest.cpp)
-  build_test(${CMAKE_SOURCE_DIR}/src/data/test/SoundTest.cpp)
+  build_test(${PROJECT_SOURCE_DIR}/src/data/test/DataTest.cpp)
+  build_test(${PROJECT_SOURCE_DIR}/src/data/test/ListFileDatasetTest.cpp)
+  build_test(${PROJECT_SOURCE_DIR}/src/data/test/SoundTest.cpp)
   # Decoder
-  build_test(${CMAKE_SOURCE_DIR}/src/decoder/test/DecoderTest.cpp)
+  build_test(${PROJECT_SOURCE_DIR}/src/decoder/test/DecoderTest.cpp)
   # Feature
-  build_test(${CMAKE_SOURCE_DIR}/src/feature/test/CeplifterTest.cpp)
-  build_test(${CMAKE_SOURCE_DIR}/src/feature/test/DctTest.cpp)
-  build_test(${CMAKE_SOURCE_DIR}/src/feature/test/DerivativesTest.cpp)
-  build_test(${CMAKE_SOURCE_DIR}/src/feature/test/DitherTest.cpp)
-  build_test(${CMAKE_SOURCE_DIR}/src/feature/test/MfccTest.cpp)
-  build_test(${CMAKE_SOURCE_DIR}/src/feature/test/PreEmphasisTest.cpp)
-  build_test(${CMAKE_SOURCE_DIR}/src/feature/test/SpeechUtilsTest.cpp)
-  build_test(${CMAKE_SOURCE_DIR}/src/feature/test/TriFilterbankTest.cpp)
-  build_test(${CMAKE_SOURCE_DIR}/src/feature/test/WindowingTest.cpp)
+  build_test(${PROJECT_SOURCE_DIR}/src/feature/test/CeplifterTest.cpp)
+  build_test(${PROJECT_SOURCE_DIR}/src/feature/test/DctTest.cpp)
+  build_test(${PROJECT_SOURCE_DIR}/src/feature/test/DerivativesTest.cpp)
+  build_test(${PROJECT_SOURCE_DIR}/src/feature/test/DitherTest.cpp)
+  build_test(${PROJECT_SOURCE_DIR}/src/feature/test/MfccTest.cpp)
+  build_test(${PROJECT_SOURCE_DIR}/src/feature/test/PreEmphasisTest.cpp)
+  build_test(${PROJECT_SOURCE_DIR}/src/feature/test/SpeechUtilsTest.cpp)
+  build_test(${PROJECT_SOURCE_DIR}/src/feature/test/TriFilterbankTest.cpp)
+  build_test(${PROJECT_SOURCE_DIR}/src/feature/test/WindowingTest.cpp)
   # Module
-  build_test(${CMAKE_SOURCE_DIR}/src/module/test/W2lModuleTest.cpp)
+  build_test(${PROJECT_SOURCE_DIR}/src/module/test/W2lModuleTest.cpp)
   # Runtime
-  build_test(${CMAKE_SOURCE_DIR}/src/runtime/test/RuntimeTest.cpp)
+  build_test(${PROJECT_SOURCE_DIR}/src/runtime/test/RuntimeTest.cpp)
 endif ()


### PR DESCRIPTION
When using wav2letter inside another project, CMAKE_SOURCE_DIR
corresponds to the top-level of the entire project, which is not
wav2letter's top-level! PROJECT_SOURCE_DIR corresponds to the
directory where the project() was last called, which should always
correspond to wav2letter's top-level directory.