### PR TITLE
[CMake] Find libgflags_debug.a correctly.

### DIFF
--- a/cmake/FindGFLAGS.cmake
+++ b/cmake/FindGFLAGS.cmake
@@ -16,7 +16,7 @@ set(GFLAGS_ROOT_DIR "" CACHE PATH "Folder contains Gflags")
 find_path(GFLAGS_INCLUDE_DIR gflags/gflags.h
     PATHS ${GFLAGS_ROOT_DIR})
 
-find_library(GFLAGS_LIBRARY gflags)
+find_library(GFLAGS_LIBRARY NAMES gflags gflags_debug)
 
 find_package_handle_standard_args(GFlags DEFAULT_MSG GFLAGS_INCLUDE_DIR GFLAGS_LIBRARY)
 


### PR DESCRIPTION
When building gflags from source with either --config debug or
CMAKE_BUILD_TYPE=Debug, gflags's library will be libgflags_debug.a,
instead of libgflags.a. This change allows the wav2letter build to
find that library successfully.

Source:

https://github.com/gflags/gflags/blob/0b7f8db2c6b1b0b2451da0923a9ab09cc610e8d1/CMakeLists.txt#L412