### PR TITLE
Bump GoogleTest/Mock min version to 1.10.0

### DIFF
--- a/cmake/BuildGoogleTest.cmake
+++ b/cmake/BuildGoogleTest.cmake
@@ -5,7 +5,7 @@ include(ExternalProject)
 set(gtest_INCLUDE_DIRS ${CMAKE_CURRENT_BINARY_DIR}/googletest/src/googletest/googletest/include)
 set(gtest_URL https://github.com/google/googletest.git)
 set(gtest_BUILD ${CMAKE_CURRENT_BINARY_DIR}/googletest/)
-set(gtest_TAG 2fe3bd994b3189899d93f1d5a881e725e046fdc2) # release 1.8.1
+set(gtest_TAG 703bd9caab50b139428cea1aaff9974ebee5742e) # release 1.10.0
 
 if (NOT TARGET gtest)
   # Download googletest
@@ -31,16 +31,14 @@ ExternalProject_Get_Property(gtest binary_dir)
 set(GTEST_BINARY_DIR ${binary_dir})
 
 # Library and include dirs
-# gmock
-set(GMOCK_LIBRARIES
-  "${GTEST_BINARY_DIR}/${CMAKE_CFG_INTDIR}/googlemock/${CMAKE_STATIC_LIBRARY_PREFIX}gmock${CMAKE_STATIC_LIBRARY_SUFFIX}"
-  "${GTEST_BINARY_DIR}/${CMAKE_CFG_INTDIR}/googlemock/${CMAKE_STATIC_LIBRARY_PREFIX}gmock_main${CMAKE_STATIC_LIBRARY_SUFFIX}"
-)
-set(GMOCK_INCLUDE_DIR ${GTEST_SOURCE_DIR}/googlemock/include)
-
-# gtest
 set(GTEST_LIBRARIES
-  "${GTEST_BINARY_DIR}/${CMAKE_CFG_INTDIR}/googlemock/gtest/${CMAKE_STATIC_LIBRARY_PREFIX}gtest${CMAKE_STATIC_LIBRARY_SUFFIX}"
-  "${GTEST_BINARY_DIR}/${CMAKE_CFG_INTDIR}/googlemock/gtest/${CMAKE_STATIC_LIBRARY_PREFIX}gtest_main${CMAKE_STATIC_LIBRARY_SUFFIX}"
+  "${GTEST_BINARY_DIR}/${CMAKE_CFG_INTDIR}/lib/${CMAKE_STATIC_LIBRARY_PREFIX}gtest${CMAKE_STATIC_LIBRARY_SUFFIX}"
+  "${GTEST_BINARY_DIR}/${CMAKE_CFG_INTDIR}/lib/${CMAKE_STATIC_LIBRARY_PREFIX}gtest_main${CMAKE_STATIC_LIBRARY_SUFFIX}"
+  "${GTEST_BINARY_DIR}/${CMAKE_CFG_INTDIR}/lib/${CMAKE_STATIC_LIBRARY_PREFIX}gmock${CMAKE_STATIC_LIBRARY_SUFFIX}"
+  "${GTEST_BINARY_DIR}/${CMAKE_CFG_INTDIR}/lib/${CMAKE_STATIC_LIBRARY_PREFIX}gmock_main${CMAKE_STATIC_LIBRARY_SUFFIX}"
 )
-set(GTEST_INCLUDE_DIR ${GTEST_SOURCE_DIR}/googletest/include)
+
+set(GTEST_INCLUDE_DIR
+  ${GTEST_SOURCE_DIR}/googletest/include
+  ${GTEST_SOURCE_DIR}/googlemock/include
+)

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -13,14 +13,12 @@ function(build_test SRCFILE)
     PRIVATE
     wav2letter++
     ${GTEST_LIBRARIES}
-    ${GMOCK_LIBRARIES}
     )
   target_include_directories(
     ${target}
     PRIVATE
     ${PROJECT_SOURCE_DIR}/..
     ${GTEST_INCLUDE_DIR}
-    ${GMOCK_INCLUDE_DIR}
     )
   target_compile_definitions(
     ${target}


### PR DESCRIPTION
Summary: Bumps requirement for GoogleTest/GoogleMock for flashlight and wav2letter to 1.10.0. Adds support for some niceties (`MOCK_METHOD(...)` with no number, `GTEST_SKIP` [very useful for some AMP and distributed tests], etc, etc). Also better-packages gtest and gmock libs.

Reviewed By: tlikhomanenko

Differential Revision: D21246761

