### PR TITLE
use older g++ version in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -57,6 +57,8 @@ jobs:
             sudo docker exec -it wav2letter bash -c "mkdir /wav2letter"
             sudo docker cp . wav2letter:/wav2letter
             sudo docker exec -it wav2letter bash -c "\
+            apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends g++-4.8 \
+            export CXX=/usr/bin/g++-4.8 \
             git clone --recursive https://github.com/facebookresearch/flashlight.git && \
             cd flashlight && mkdir -p build && cd build && \
             cmake .. -DCMAKE_BUILD_TYPE=Debug -DFLASHLIGHT_BACKEND=CUDA -DFL_BUILD_CONTRIB=ON -DFL_BUILD_TESTS=OFF -DFL_BUILD_EXAMPLES=OFF && \
@@ -78,7 +80,9 @@ jobs:
           # Tests and examples are built in the CUDA backend workflow, and since we're not running CPU tests anyways, ignore
           # and only build core library components (e.g. CPU criterion, etc)
           command: |
-            export MKLROOT=/opt/intel/mkl && mkdir -p build && cd build
+            apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends g++-4.8
+            export MKLROOT=/opt/intel/mkl && export CXX=/usr/bin/g++-4.8
+            mkdir -p build && cd build
             cd /root && git clone --recursive https://github.com/facebookresearch/flashlight.git && \
             cd flashlight && mkdir -p build && cd build && \
             cmake .. -DCMAKE_BUILD_TYPE=Debug -DFLASHLIGHT_BACKEND=CPU -DFL_BUILD_CONTRIB=ON -DFL_BUILD_TESTS=OFF -DFL_BUILD_EXAMPLES=OFF && \


### PR DESCRIPTION
Summary:
- use g++4.8 for the CI and tests (to prevent new features from newest compiler)
- the newest version of g++ will be used and tested inside docker build

Reviewed By: jacobkahn

Differential Revision: D21282538

