### PR TITLE
Remove straggler unwrapped mem step size functions

### DIFF
--- a/recipes/models/local_prior_match/Decode_length_lpm.cpp
+++ b/recipes/models/local_prior_match/Decode_length_lpm.cpp
@@ -63,7 +63,7 @@ int main(int argc, char** argv) {
 
   LOG(INFO) << "[network] " << network->prettyString();
 
-  af::setMemStepSize(FLAGS_memstepsize);
+  fl::afSetMemStepSize(FLAGS_memstepsize);
   af::setSeed(FLAGS_seed);
 
   DictionaryMap dicts;

--- a/recipes/models/local_prior_match/Train_lpm.cpp
+++ b/recipes/models/local_prior_match/Train_lpm.cpp
@@ -53,7 +53,7 @@ int main(int argc, char** argv) {
   std::string runStatus = config[kRunStatus];
 
   /* ================ Set up distributed environment ================ */
-  af::setMemStepSize(FLAGS_memstepsize);
+  fl::afSetMemStepSize(FLAGS_memstepsize);
   af::setSeed(FLAGS_seed);
   af::setFFTPlanCacheSize(FLAGS_fftcachesize);
 

--- a/src/criterion/Seq2SeqCriterion.cpp
+++ b/src/criterion/Seq2SeqCriterion.cpp
@@ -494,8 +494,8 @@ std::pair<Variable, Seq2SeqState> Seq2SeqCriterion::decodeStep(
     const Variable& xEncoded,
     const Variable& y,
     const Seq2SeqState& inState) const {
-  size_t stepSize = afGetMemStepSize();
-  afSetMemStepSize(10 * (1 << 10));
+  size_t stepSize = fl::afGetMemStepSize();
+  fl::afSetMemStepSize(10 * (1 << 10));
   Variable hy;
   if (y.isempty()) {
     hy = tile(startEmbedding(), {1, 1, static_cast<int>(xEncoded.dims(2))});
@@ -532,7 +532,7 @@ std::pair<Variable, Seq2SeqState> Seq2SeqCriterion::decodeStep(
   outState.summary = summaries;
 
   auto out = linearOut()->forward(hy); // C x 1 x B
-  afSetMemStepSize(stepSize);
+  fl::afSetMemStepSize(stepSize);
   return std::make_pair(out, outState);
 }
 
@@ -544,8 +544,8 @@ Seq2SeqCriterion::decodeBatchStep(
     const int attentionThreshold,
     const float smoothingTemperature) const {
   // NB: xEncoded has to be with batchsize 1
-  size_t stepSize = af::getMemStepSize();
-  af::setMemStepSize(10 * (1 << 10));
+  size_t stepSize = fl::afGetMemStepSize();
+  fl::afSetMemStepSize(10 * (1 << 10));
   int batchSize = ys.size();
   std::vector<Variable> statesVector(batchSize);
 
@@ -625,7 +625,7 @@ Seq2SeqCriterion::decodeBatchStep(
     out[i] = w2l::afToVector<float>(outBatched.col(i));
   }
 
-  af::setMemStepSize(stepSize);
+  fl::afSetMemStepSize(stepSize);
   return std::make_pair(out, outstates);
 }
 

--- a/src/criterion/TransformerCriterion.cpp
+++ b/src/criterion/TransformerCriterion.cpp
@@ -231,8 +231,8 @@ std::pair<Variable, TS2SState> TransformerCriterion::decodeStep(
     const Variable& xEncoded,
     const Variable& y,
     const TS2SState& inState) const {
-  size_t stepSize = af::getMemStepSize();
-  af::setMemStepSize(100 * (1 << 10));
+  size_t stepSize = fl::afGetMemStepSize();
+  fl::afSetMemStepSize(100 * (1 << 10));
 
   Variable hy;
   if (y.isempty()) {
@@ -268,7 +268,7 @@ std::pair<Variable, TS2SState> TransformerCriterion::decodeStep(
   hy = hy + summary;
 
   auto out = linearOut()->forward(hy);
-  af::setMemStepSize(stepSize);
+  fl::afSetMemStepSize(stepSize);
   return std::make_pair(out, outState);
 }
 
@@ -279,8 +279,8 @@ TransformerCriterion::decodeBatchStep(
     const std::vector<TS2SState*>& inStates,
     const int /* attentionThreshold */,
     const float smoothingTemperature) const {
-  size_t stepSize = af::getMemStepSize();
-  af::setMemStepSize(10 * (1 << 10));
+  size_t stepSize = fl::afGetMemStepSize();
+  fl::afSetMemStepSize(10 * (1 << 10));
   int B = ys.size();
 
   for (int i = 0; i < B; i++) {
@@ -335,7 +335,7 @@ TransformerCriterion::decodeBatchStep(
     out[i] = w2l::afToVector<float>(outBatched.col(i));
   }
 
-  af::setMemStepSize(stepSize);
+  fl::afSetMemStepSize(stepSize);
   return std::make_pair(out, outstates);
 }
 


### PR DESCRIPTION
Summary: D21230163 didn't remove all calls to `af::setMemStepSize` and `af::getMemStepSize` -- remove and replace with `afSetMemStepSize` and `afGetMemStepSize`

Differential Revision: D21371240

