### PR TITLE
Allow type specification for tensor reduction in w2l

### DIFF
--- a/Train.cpp
+++ b/Train.cpp
@@ -141,7 +141,10 @@ int main(int argc, char** argv) {
         FLAGS_max_devices_per_node,
         FLAGS_rndv_filepath);
     reducer = std::make_shared<fl::CoalescingReducer>(
-        1.0 / fl::getWorldSize(), true, true);
+        1.0 / fl::getWorldSize(),
+        true,
+        true,
+        fl::stringToAfType(FLAGS_reducer_dtype));
   }
 
   int worldRank = fl::getWorldRank();

--- a/recipes/models/local_prior_match/Train_lpm.cpp
+++ b/recipes/models/local_prior_match/Train_lpm.cpp
@@ -65,7 +65,10 @@ int main(int argc, char** argv) {
         FLAGS_max_devices_per_node,
         FLAGS_rndv_filepath);
     reducer = std::make_shared<fl::CoalescingReducer>(
-        1.0 / fl::getWorldSize(), true, true);
+        1.0 / fl::getWorldSize(),
+        true,
+        true,
+        fl::stringToAfType(FLAGS_reducer_dtype));
   }
 
   int worldRank = fl::getWorldRank();

--- a/src/common/Defines.cpp
+++ b/src/common/Defines.cpp
@@ -323,9 +323,14 @@ DEFINE_int64(
     8,
     "the maximum number of devices per training node");
 DEFINE_string(
+    reducer_dtype,
+    "f32",
+    "if supported by the reducer, the type to "
+    "which reduced tensors are cast and synchronized");
+DEFINE_string(
     rndv_filepath,
     "",
-    "Shared file path used for setting up rendezvous."
+    "Shared file path used for setting up rendezvous. "
     "If empty, uses MPI to initialize.");
 
 // FB SPECIFIC

--- a/src/common/Defines.h
+++ b/src/common/Defines.h
@@ -298,6 +298,7 @@ DECLARE_bool(enable_distributed);
 DECLARE_int64(world_rank);
 DECLARE_int64(world_size);
 DECLARE_int64(max_devices_per_node);
+DECLARE_string(reducer_dtype);
 DECLARE_string(rndv_filepath);
 
 /* ========== FB SPECIFIC ========== */


### PR DESCRIPTION
Summary:
*tl;dr*: Sync your gradients in fp16 by passing `--reducer_dtype f16` when starting training. Default is fp32.

If the reducer supports it (only `CoalescingReducer`), passing a type casts all Variables to that type before synchronizing.

Differential Revision: D21297679

