### PR TITLE
improve convlm prediction with no reoreder and .row.col operations

### DIFF
--- a/src/libraries/lm/ConvLM.h
+++ b/src/libraries/lm/ConvLM.h
@@ -16,8 +16,8 @@
 
 namespace w2l {
 
-using GetConvLmScoreFunc = std::function<std::vector<std::vector<
-    float>>(const std::vector<int>&, const std::vector<int>&, int, int)>;
+using GetConvLmScoreFunc = std::function<std::vector<
+    float>(const std::vector<int>&, const std::vector<int>&, int, int)>;
 
 struct ConvLMState : LMState {
   std::vector<int> tokens;

--- a/src/module/ConvLmModule.h
+++ b/src/module/ConvLmModule.h
@@ -13,8 +13,8 @@
 
 namespace w2l {
 
-using GetConvLmScoreFunc = std::function<std::vector<std::vector<
-    float>>(const std::vector<int>&, const std::vector<int>&, int, int)>;
+using GetConvLmScoreFunc = std::function<std::vector<
+    float>(const std::vector<int>&, const std::vector<int>&, int, int)>;
 
 GetConvLmScoreFunc buildGetConvLmScoreFunction(
     std::shared_ptr<fl::Module> network);


### PR DESCRIPTION
Summary:
- remove reorder and .row.col operation in convlm prediction function
- speed up on 1 GPU 17%, on 8 GPU is the same

Reviewed By: xuqiantong

Differential Revision: D21814103

