### PR TITLE
fix docker build action; remove CI and docker badges in w2l

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,23 @@
+ # Copyright (c) Facebook, Inc. and its affiliates.
+ # All rights reserved.
+ #
+ # This source code is licensed under the BSD-style license found in the
+ # LICENSE file in the root directory of this source tree.
+
+version: 2.0
+
+jobs:
+  build-cpu:
+    docker:
+      - image: wav2letter/wav2letter:cpu-base-latest
+    steps:
+      - checkout
+      - run:
+          name: nothing
+          command: |
+            echo "Hello world"
+workflows:
+  version: 2
+  build_and_install:
+    jobs:
+      - build-cpu

--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 # wav2letter++
 
-[![CircleCI](https://circleci.com/gh/facebookresearch/wav2letter.svg?style=svg)](https://circleci.com/gh/facebookresearch/wav2letter)
-[![](https://github.com/facebookresearch/wav2letter/workflows/Publish%20Docker%20images/badge.svg)](https://hub.docker.com/r/wav2letter/wav2letter/tags)
 [![Join the chat at https://gitter.im/wav2letter/community](https://badges.gitter.im/wav2letter/community.svg)](https://gitter.im/wav2letter/community?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
 **Please use for now stable version at https://github.com/facebookresearch/wav2letter/tree/v0.2. We are restucturing and moving things to the [flashlight](https://github.com/facebookresearch/flashlight)**


### PR DESCRIPTION
Summary:
- fix docker image build actions in flashlight
- remove badges in w2l

Reviewed By: jacobkahn

Differential Revision: D23278429

