### PR TITLE
improve CMake with better linking of arrayfire and app installation; cmake of recipes in w2l (#157)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,4 +1,4 @@
- # Copyright (c) Facebook, Inc. and its affiliates.
+# Copyright (c) Facebook, Inc. and its affiliates.
  # All rights reserved.
  #
  # This source code is licensed under the BSD-style license found in the
@@ -6,18 +6,67 @@
 
 version: 2.0
 
+gpu: &gpu
+  machine:
+    image: ubuntu-1604:201903-01
+  resource_class: gpu.small
+
 jobs:
-  build-cpu:
-    docker:
-      - image: wav2letter/wav2letter:cpu-base-latest
+  build-cuda:
+    <<: *gpu
     steps:
       - checkout
       - run:
-          name: nothing
+          name: Setup Docker and nvidia-docker
           command: |
-            echo "Hello world"
+            # Install CUDA 10.0
+            wget https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1604/x86_64/cuda-repo-ubuntu1604_10.0.130-1_amd64.deb
+            sudo dpkg -i cuda-repo-ubuntu1604_10.0.130-1_amd64.deb
+            sudo apt-get update || true
+            sudo apt-get --yes --force-yes install cuda
+            nvidia-smi
+            # Install Docker
+            sudo apt-get update
+            sudo apt-get install \
+            apt-transport-https \
+            ca-certificates \
+            curl \
+            software-properties-common
+            curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
+            sudo apt-key fingerprint 0EBFCD88
+            sudo add-apt-repository \
+            "deb [arch=amd64] https://download.docker.com/linux/ubuntu \
+            $(lsb_release -cs) \
+            stable"
+            sudo apt-get update
+            sudo apt-get install docker-ce
+            # Install nvidia-docker
+            curl -s -L https://nvidia.github.io/nvidia-docker/gpgkey | \
+            sudo apt-key add -
+            distribution=$(. /etc/os-release;echo $ID$VERSION_ID)
+            curl -s -L https://nvidia.github.io/nvidia-docker/$distribution/nvidia-docker.list | \
+            sudo tee /etc/apt/sources.list.d/nvidia-docker.list
+            sudo apt-get update
+            # Install nvidia-docker2 and reload the Docker daemon configuration
+            sudo apt-get install -y nvidia-docker2
+            sudo pkill -SIGHUP dockerd
+      - run:
+          name: Build flashlight with CUDA backend inside nvidia-docker
+          command: |
+            sudo docker run --runtime=nvidia --rm -itd --ipc=host --name wav2letter flml/flashlight:cuda-base-consolidation-latest
+            sudo docker exec -it wav2letter bash -c "mkdir /wav2letter"
+            sudo docker cp . wav2letter:/wav2letter
+            sudo docker exec -it wav2letter bash -c "\
+            apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends gcc-5 g++-5 && \
+            git clone https://github.com/facebookresearch/flashlight.git && \
+            cd flashlight && pwd && ls && mkdir -p build && cd build && \
+            export CC=/usr/bin/gcc-5 && export CXX=/usr/bin/g++-5 && \
+            export MKLROOT=/opt/intel/mkl && export KENLM_ROOT_DIR=/root/kenlm && \
+            cmake .. -DFL_BACKEND=CUDA && \
+            make -j$(nproc) && make install && \
+            cd /wav2letter && mkdir build && cd build && cmake .. && make -j$(nproc)"
 workflows:
   version: 2
   build_and_install:
     jobs:
-      - build-cpu
+      - build-cuda

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,48 @@
+cmake_minimum_required(VERSION 3.5.1)
+
+project(wav2letter++)
+
+# C++ 11 is required
+set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_PROJECT_SOURCE "${CMAKE_CURRENT_LIST_DIR}")
+
+# Find and setup OpenMP
+find_package(OpenMP)
+if (OPENMP_FOUND)
+  message(STATUS "OpenMP found")
+  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${OpenMP_C_FLAGS}")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${OpenMP_CXX_FLAGS}")
+  set(CMAKE_EXE_LINKER_FLAGS
+    "${CMAKE_EXE_LINKER_FLAGS} ${OpenMP_EXE_LINKER_FLAGS}"
+  )
+else()
+  message(STATUS "OpenMP not found - building without OpenMP")
+endif()
+
+# ArrayFire
+# The correct ArrayFire backend target is transitively included by flashlight
+find_package(ArrayFire 3.6.1 REQUIRED)
+if (ArrayFire_FOUND)
+  message(STATUS "ArrayFire found (include: ${ArrayFire_INCLUDE_DIRS}, library: ${ArrayFire_LIBRARIES})")
+else()
+  message(FATAL_ERROR "ArrayFire not found")
+endif()
+
+find_package(flashlight REQUIRED)
+if (flashlight_FOUND)
+  message(STATUS "flashlight found (include: ${FLASHLIGHT_INCLUDE_DIRS} lib: flashlight::flashlight )")
+  if (NOT TARGET flashlight::flashlight-app-asr)
+    message(FATAL_ERROR "flashlight must be build with app/asr for wav2letter++")
+  else ()
+    message(STATUS "flashlight/app/asr is found.")
+  endif ()
+  if (NOT TARGET flashlight::fl-libraries)
+    message(FATAL_ERROR "flashlight must be build with lib for wav2letter++")
+  else ()
+    message(STATUS "flashlight/lib is found.")
+  endif ()
+endif ()
+
+
+add_subdirectory(${PROJECT_SOURCE_DIR}/recipes)

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # wav2letter++
 
+[![CircleCI](https://circleci.com/gh/facebookresearch/wav2letter.svg?style=svg)](https://circleci.com/gh/facebookresearch/wav2letter)
 [![Join the chat at https://gitter.im/wav2letter/community](https://badges.gitter.im/wav2letter/community.svg)](https://gitter.im/wav2letter/community?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
 wav2letter++ is a [highly efficient](https://arxiv.org/abs/1812.07625) end-to-end automatic speech recognition (ASR) toolkit written entirely in C++, leveraging [ArrayFire](https://github.com/arrayfire/arrayfire) and [flashlight](https://github.com/facebookresearch/flashlight).
@@ -22,6 +23,13 @@ Data preparation for our training and evaluation can be found in [data](data) fo
 The previous iteration of wav2letter can be found in the:
 - (before merging codebases for wav2letter and flashlight) [wav2letter-v0.2](https://github.com/facebookresearch/wav2letter/tree/v0.2) branch.
 - (written in Lua) [`wav2letter-lua`](https://github.com/facebookresearch/wav2letter/tree/wav2letter-lua) branch.
+
+## Build recipes
+At first install flashlight with all its dependencies. Then
+```
+mkdir build && cd build && cmake .. && make -j8
+```
+To link arrayfire and flashlight from specific installed paths, use `cmake .. -Dflashlight_DIR=[PREFIX]/usr/share/flashlight/cmake/ -DArrayFire_DIR=[PREFIX]/usr/share/ArrayFire/cmake`
 
 ## Join the wav2letter community
 * Facebook page: https://www.facebook.com/groups/717232008481207/

--- a/recipes/CMakeLists.txt
+++ b/recipes/CMakeLists.txt
@@ -1,8 +1,8 @@
 cmake_minimum_required(VERSION 3.5.1)
 
-project(wav2letter++-recipes)
+project(wav2letter++)
 
 # Scripts which are common for our recipes
 add_subdirectory(${PROJECT_SOURCE_DIR}/utilities/convlm_serializer)
-add_subdirectory(${PROJECT_SOURCE_DIR}/local_prior_match)
-add_subdirectory(${PROJECT_SOURCE_DIR}/self_training/pseudo_labeling)
+#add_subdirectory(${PROJECT_SOURCE_DIR}/local_prior_match)
+#add_subdirectory(${PROJECT_SOURCE_DIR}/self_training/pseudo_labeling)

--- a/recipes/utilities/convlm_serializer/CMakeLists.txt
+++ b/recipes/utilities/convlm_serializer/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.5.1)
 
-project(wav2letter++-recipes-models-utilities-convlm_serializer)
+project(wav2letter++-recipes-utilities-convlm_serializer)
 
 add_executable(
     SerializeConvLM
@@ -11,16 +11,14 @@ add_executable(
 target_include_directories(
     SerializeConvLM
     PUBLIC
-    ${PROJECT_SOURCE_DIR}/../../../..
+    ${CMAKE_PROJECT_SOURCE}
   )
 
 target_link_libraries(
   SerializeConvLM
   PUBLIC
-  wav2letter++
-  runtime
-  common
-  module
+  flashlight::flashlight
+  flashlight::flashlight-app-asr
   ${GLOG_LIBRARIES}
   )
 
@@ -39,8 +37,7 @@ target_link_libraries(
   convlm-serializer
   INTERFACE
   flashlight::flashlight
-  module
-  common
+  flashlight::flashlight-app-asr
   ${GLOG_LIBRARIES}
   )
 
@@ -48,5 +45,5 @@ target_include_directories(
   convlm-serializer
   INTERFACE
   ${GLOG_INCLUDE_DIRS}
-  ${PROJECT_SOURCE_DIR}/../../../..
+  ${CMAKE_PROJECT_SOURCE}
   )

--- a/recipes/utilities/convlm_serializer/Utils.cpp
+++ b/recipes/utilities/convlm_serializer/Utils.cpp
@@ -1,6 +1,6 @@
 #include "recipes/utilities/convlm_serializer/Utils.h"
+#include <flashlight/contrib/modules/modules.h>
 #include <flashlight/ext/common/SequentialBuilder.h>
-#include <flashlight/flashlight/contrib/modules/modules.h>
 #include <flashlight/lib/common/String.h>
 #include <flashlight/lib/common/System.h>
 #include <glog/logging.h>

--- a/recipes/utilities/convlm_serializer/Utils.h
+++ b/recipes/utilities/convlm_serializer/Utils.h
@@ -7,7 +7,7 @@
  */
 #pragma once
 
-#include <flashlight/flashlight/flashlight.h>
+#include <flashlight/flashlight.h>
 #include <string>
 #include <vector>
 


### PR DESCRIPTION
Summary:
Pull Request resolved: https://github.com/facebookresearch/flashlight/pull/157

- make installable parts of flashlight/app
- fix linking problem with arrayfire for some machines
- add cmake and circle ci for the w2l to build recipes with proper linking of flashlight and flashlight app
- add readme how to build recipes

Differential Revision: D23509888

