### PR TITLE
Don't build fl tests/examples for w2l OS CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -62,7 +62,7 @@ jobs:
             cd flashlight && pwd && ls && mkdir -p build && cd build && \
             export CC=/usr/bin/gcc-5 && export CXX=/usr/bin/g++-5 && \
             export MKLROOT=/opt/intel/mkl && export KENLM_ROOT_DIR=/root/kenlm && \
-            cmake .. -DFL_BACKEND=CUDA && \
+            cmake .. -DFL_BACKEND=CUDA -DFL_BUILD_TESTS=OFF -DFL_BUILD_EXAMPLES=OFF && \
             make -j$(nproc) && make install && \
             cd /wav2letter && mkdir build && cd build && cmake .. && make -j$(nproc)"
 workflows:


### PR DESCRIPTION
Summary: Things are really slow right now; since we have static builds enabled by default for flashlight. Let's just not build tests and examples when building w2l since they're already tested in flashlight CI and we don't need them for w2l.

Reviewed By: tlikhomanenko

Differential Revision: D23610278

