### PR TITLE
Manually search for fl asr deps

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,7 @@ project(wav2letter++)
 # C++ 11 is required
 set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/cmake")
 
 # Find and setup OpenMP
 find_package(OpenMP)
@@ -43,5 +44,8 @@ if (flashlight_FOUND)
   endif ()
 endif ()
 
+# Dependencies
+find_package(FFTW3 REQUIRED)
+find_package(SndFile REQUIRED)
 
 add_subdirectory(${PROJECT_SOURCE_DIR}/recipes)

--- a/cmake/FindFFTW3.cmake
+++ b/cmake/FindFFTW3.cmake
@@ -1,0 +1,123 @@
+# - Find the FFTW library
+#
+# Usage:
+#   find_package(FFTW [REQUIRED] [QUIET] )
+#
+# Provides the following config targets:
+# - FFTW3::fftw3
+#
+# It sets the following variables:
+#   FFTW_FOUND               ... true if fftw is found on the system
+#   FFTW_LIBRARIES           ... full path to fftw library
+#   FFTW_INCLUDES            ... fftw include directory
+#
+# The following variables will be checked by the function
+#   FFTW_USE_STATIC_LIBS    ... if true, only static libraries are found
+#   FFTW_ROOT               ... if set, the libraries are exclusively searched
+#                               under this path
+#   FFTW_LIBRARY            ... fftw library to use
+#   FFTW_INCLUDE_DIR        ... fftw include directory
+#
+
+find_package(FFTW3 CONFIG)
+
+if (NOT TARGET FFTW3::fftw3)
+  # If environment variable FFTWDIR is specified, it has same effect as FFTW_ROOT
+  if (NOT FFTW_ROOT AND ENV{FFTWDIR} )
+    set( FFTW_ROOT $ENV{FFTWDIR} )
+  endif()
+  # Check if we can use PkgConfig
+  find_package(PkgConfig)
+  #Determine from PKG
+  if (PKG_CONFIG_FOUND AND NOT FFTW_ROOT )
+    pkg_check_modules( PKG_FFTW QUIET "fftw3" )
+  endif()
+  #Check whether to search static or dynamic libs
+  set( CMAKE_FIND_LIBRARY_SUFFIXES_SAV ${CMAKE_FIND_LIBRARY_SUFFIXES} )
+  if (${FFTW_USE_STATIC_LIBS} )
+    set( CMAKE_FIND_LIBRARY_SUFFIXES ${CMAKE_STATIC_LIBRARY_SUFFIX} )
+  else()
+    set( CMAKE_FIND_LIBRARY_SUFFIXES ${CMAKE_SHARED_LIBRARY_SUFFIX} )
+  endif()
+  if (FFTW_ROOT )
+    #find libs
+    find_library(
+      FFTW_LIB
+      NAMES "fftw3"
+      PATHS ${FFTW_ROOT}
+      PATH_SUFFIXES "lib" "lib64"
+      NO_DEFAULT_PATH
+      )
+    find_library(
+      FFTWF_LIB
+      NAMES "fftw3f"
+      PATHS ${FFTW_ROOT}
+      PATH_SUFFIXES "lib" "lib64"
+      NO_DEFAULT_PATH
+      )
+    find_library(
+      FFTWL_LIB
+      NAMES "fftw3l"
+      PATHS ${FFTW_ROOT}
+      PATH_SUFFIXES "lib" "lib64"
+      NO_DEFAULT_PATH
+      )
+    #find includes
+    find_path(
+      FFTW_INCLUDES
+      NAMES "fftw3.h"
+      PATHS ${FFTW_ROOT}
+      PATH_SUFFIXES "include"
+      NO_DEFAULT_PATH
+      )
+  else()
+    find_library(
+      FFTW_LIB
+      NAMES "fftw3"
+      PATHS ${PKG_FFTW_LIBRARY_DIRS} ${LIB_INSTALL_DIR}
+      )
+    find_library(
+      FFTWF_LIB
+      NAMES "fftw3f"
+      PATHS ${PKG_FFTW_LIBRARY_DIRS} ${LIB_INSTALL_DIR}
+      )
+    find_library(
+      FFTWL_LIB
+      NAMES "fftw3l"
+      PATHS ${PKG_FFTW_LIBRARY_DIRS} ${LIB_INSTALL_DIR}
+      )
+    find_path(
+      FFTW_INCLUDES
+      NAMES "fftw3.h"
+      PATHS ${PKG_FFTW_INCLUDE_DIRS} ${INCLUDE_INSTALL_DIR}
+      )
+  endif (FFTW_ROOT )
+  set(FFTW_LIBRARIES ${FFTW_LIB} ${FFTWF_LIB})
+  if(FFTWL_LIB)
+    set(FFTW_LIBRARIES ${FFTW_LIBRARIES} ${FFTWL_LIB})
+  endif()
+  set( CMAKE_FIND_LIBRARY_SUFFIXES ${CMAKE_FIND_LIBRARY_SUFFIXES_SAV} )
+  include(FindPackageHandleStandardArgs)
+  find_package_handle_standard_args(FFTW DEFAULT_MSG
+    FFTW_INCLUDES FFTW_LIBRARIES)
+  mark_as_advanced(FFTW_INCLUDES FFTW_LIBRARIES FFTW_LIB FFTWF_LIB FFTWL_LIB)
+  if (FFTW_FOUND)
+    add_library(FFTW3::fftw3 UNKNOWN IMPORTED)
+    set_target_properties(FFTW3::fftw3 PROPERTIES
+      INTERFACE_INCLUDE_DIRECTORIES "${FFTW_INCLUDES}"
+      IMPORTED_LOCATION "${FFTW_LIB}"
+      )
+    add_library(FFTW3::fftw3f UNKNOWN IMPORTED)
+    set_target_properties(FFTW3::fftw3f PROPERTIES
+      INTERFACE_INCLUDE_DIRECTORIES "${FFTW_INCLUDES}"
+      IMPORTED_LOCATION "${FFTWF_LIB}"
+      )
+    add_library(FFTW3::fftw3l UNKNOWN IMPORTED)
+    set_target_properties(FFTW3::fftw3l PROPERTIES
+      INTERFACE_INCLUDE_DIRECTORIES "${FFTW_INCLUDES}"
+      IMPORTED_LOCATION "${FFTWL_LIB}"
+      )
+
+  endif()
+
+endif(NOT TARGET FFTW3::fftw3)

--- a/cmake/FindFLAC.cmake
+++ b/cmake/FindFLAC.cmake
@@ -1,0 +1,81 @@
+# - Find FLAC
+# Find the native FLAC includes and libraries
+#
+# Sets the following imported targets if FLAC is found:
+# FLAC::FLAC
+#
+# Sets the following legacy CMake variables:
+#  FLAC_INCLUDE_DIRS - where to find FLAC headers.
+#  FLAC_LIBRARIES    - List of libraries when using libFLAC.
+#  FLAC_FOUND        - True if libFLAC found.
+#  FLAC_DEFINITIONS  - FLAC compile definitons
+
+if (FLAC_INCLUDE_DIR)
+    # Already in cache, be silent
+    set (FLAC_FIND_QUIETLY TRUE)
+endif ()
+
+find_package (Ogg QUIET)
+
+find_package (PkgConfig QUIET)
+pkg_check_modules(PC_FLAC QUIET flac)
+
+set(FLAC_VERSION ${PC_FLAC_VERSION})
+
+find_path (FLAC_INCLUDE_DIR FLAC/stream_decoder.h
+	HINTS
+		${PC_FLAC_INCLUDEDIR}
+		${PC_FLAC_INCLUDE_DIRS}
+		${FLAC_ROOT}
+	)
+
+# MSVC built libraries can name them *_static, which is good as it
+# distinguishes import libraries from static libraries with the same extension.
+find_library (FLAC_LIBRARY
+	NAMES
+		FLAC
+		libFLAC
+		libFLAC_dynamic
+		libFLAC_static
+	HINTS
+		${PC_FLAC_LIBDIR}
+		${PC_FLAC_LIBRARY_DIRS}
+		${FLAC_ROOT}
+	)
+
+# Handle the QUIETLY and REQUIRED arguments and set FLAC_FOUND to TRUE if
+# all listed variables are TRUE.
+include (FindPackageHandleStandardArgs)
+find_package_handle_standard_args (FLAC
+	REQUIRED_VARS
+		FLAC_LIBRARY
+		FLAC_INCLUDE_DIR
+		OGG_FOUND
+	VERSION_VAR
+        FLAC_VERSION
+	)
+
+if (FLAC_FOUND)
+	set (FLAC_INCLUDE_DIRS ${FLAC_INCLUDE_DIR})
+	set (FLAC_LIBRARIES ${FLAC_LIBRARY} ${OGG_LIBRARIES})
+	if (WIN32)
+		set (FLAC_LIBRARIES ${FLAC_LIBRARIES} wsock32)
+		get_filename_component (FLAC_LIBRARY_FILENAME ${FLAC_LIBRARY} NAME_WE)
+		if (FLAC_LIBRARY_FILENAME MATCHES "libFLAC_static")
+			set (FLAC_DEFINITIONS -DFLAC__NO_DLL)
+		endif ()
+	endif ()
+    if (NOT TARGET FLAC::FLAC)
+		add_library(FLAC::FLAC UNKNOWN IMPORTED)
+		set_target_properties(FLAC::FLAC PROPERTIES
+			INTERFACE_INCLUDE_DIRECTORIES "${FLAC_INCLUDE_DIR}"
+			IMPORTED_LOCATION "${FLAC_LIBRARY}"
+			INTERFACE_LINK_LIBRARIES
+				Ogg::ogg
+				$<$<BOOL:${WIN32}>:wsock32>
+			INTERFACE_COMPILE_DEFINITIONS ${FLAC_DEFINITIONS}
+			)
+	endif ()
+endif ()
+
+mark_as_advanced(FLAC_INCLUDE_DIR FLAC_LIBRARY)

--- a/cmake/FindOgg.cmake
+++ b/cmake/FindOgg.cmake
@@ -1,0 +1,65 @@
+# - Find ogg
+# Find the native ogg includes and libraries
+#
+#  OGG_INCLUDE_DIRS - where to find ogg.h, etc.
+#  OGG_LIBRARIES    - List of libraries when using ogg.
+#  OGG_FOUND        - True if ogg found.
+
+find_package(Ogg CONFIG)
+
+if (NOT TARGET Ogg::ogg)
+  if (OGG_INCLUDE_DIR)
+    # Already in cache, be silent
+    set(OGG_FIND_QUIETLY TRUE)
+  endif()
+
+  find_package(PkgConfig QUIET)
+  pkg_check_modules(PC_OGG QUIET ogg)
+
+  set(OGG_VERSION ${PC_OGG_VERSION})
+
+  find_path(OGG_INCLUDE_DIR ogg/ogg.h
+    HINTS
+      ${PC_OGG_INCLUDEDIR}
+      ${PC_OGG_INCLUDE_DIRS}
+      ${OGG_ROOT}
+    )
+  # MSVC built ogg may be named ogg_static.
+  # The provided project files name the library with the lib prefix.
+  find_library(OGG_LIBRARY
+    NAMES
+      ogg
+      ogg_static
+      libogg
+      libogg_static
+    HINTS
+      ${PC_OGG_LIBDIR}
+      ${PC_OGG_LIBRARY_DIRS}
+      ${OGG_ROOT}
+    )
+  # Handle the QUIETLY and REQUIRED arguments and set OGG_FOUND
+  # to TRUE if all listed variables are TRUE.
+  include(FindPackageHandleStandardArgs)
+  find_package_handle_standard_args(Ogg
+    REQUIRED_VARS
+      OGG_LIBRARY
+      OGG_INCLUDE_DIR
+    VERSION_VAR
+      OGG_VERSION
+    )
+
+  if (OGG_FOUND)
+    set(OGG_LIBRARIES ${OGG_LIBRARY})
+    set(OGG_INCLUDE_DIRS ${OGG_INCLUDE_DIR})
+
+    if(NOT TARGET Ogg::ogg)
+    add_library(Ogg::ogg UNKNOWN IMPORTED)
+      set_target_properties(Ogg::ogg PROPERTIES
+        INTERFACE_INCLUDE_DIRECTORIES "${OGG_INCLUDE_DIRS}"
+        IMPORTED_LOCATION "${OGG_LIBRARY}"
+      )
+    endif()
+  endif()
+
+  mark_as_advanced(OGG_INCLUDE_DIR OGG_LIBRARY)
+endif()

--- a/cmake/FindSndFile.cmake
+++ b/cmake/FindSndFile.cmake
@@ -1,0 +1,81 @@
+# Try to find libsndfile
+#
+# Provides the cmake config target
+# - SndFile::sndfile
+#
+# Inputs:
+#   SNDFILE_INC_DIR: include directory for sndfile headers
+#   SNDFILE_LIB_DIR: directory containing sndfile libraries
+#   SNDFILE_ROOT_DIR: directory containing sndfile installation
+#
+# Defines:
+#  SNDFILE_FOUND - system has libsndfile
+#  SNDFILE_INCLUDE_DIRS - the libsndfile include directory
+#  SNDFILE_LIBRARIES - Link these to use libsndfile
+#
+
+# We require sndfile having been built with external libs.
+find_package(Ogg REQUIRED)
+find_package(Vorbis REQUIRED)
+find_package(FLAC REQUIRED)
+
+find_package(SndFile CONFIG)
+
+if (TARGET SndFile::sndfile AND NOT SndFile_WITH_EXTERNAL_LIBS)
+  message(WARNING "Found sndfile but was NOT built with external libs.")
+endif()
+
+if (NOT TARGET SndFile::sndfile)
+  find_path(
+    SNDFILE_INCLUDE_DIR
+      sndfile.h
+    PATHS
+    ${SNDFILE_INC_DIR}
+    ${SNDFILE_ROOT_DIR}/include
+    PATH_SUFFIXES
+    include
+    )
+
+  find_library(
+    SNDFILE_LIBRARY
+    sndfile
+    PATHS
+    ${SNDFILE_LIB_DIR}
+    ${SNDFILE_ROOT_DIR}
+    PATH_SUFFIXES
+    lib
+    HINTS
+    SNDFILE
+    )
+
+  set(SNDFILE_INCLUDE_DIRS
+    ${SNDFILE_INCLUDE_DIR}
+    )
+  set(SNDFILE_LIBRARIES
+    ${SNDFILE_LIBRARY}
+    )
+
+  mark_as_advanced(SNDFILE_INCLUDE_DIRS SNDFILE_LIBRARIES)
+  include(FindPackageHandleStandardArgs)
+  find_package_handle_standard_args(SNDFILE DEFAULT_MSG SNDFILE_INCLUDE_DIRS GLOG_LIBRARIES)
+
+  add_library(SndFile::sndfile UNKNOWN IMPORTED)
+  set_target_properties(SndFile::sndfile PROPERTIES
+    INTERFACE_INCLUDE_DIRECTORIES "${SNDFILE_INCLUDE_DIRS}"
+    IMPORTED_LOCATION "${SNDFILE_LIBRARIES}"
+    )
+  set_property(
+    TARGET SndFile::sndfile
+    PROPERTY INTERFACE_LINK_LIBRARIES
+    Vorbis::vorbis
+    Vorbis::vorbisenc
+    Ogg::ogg
+    FLAC::FLAC
+    )
+
+  if (SNDFILE_FOUND)
+    message(STATUS "Found libsndfile: (lib: ${SNDFILE_LIBRARIES} include: ${SNDFILE_INCLUDE_DIRS}")
+  else()
+    message(STATUS "libsndfile not found.")
+  endif()
+endif() # NOT TARGET SndFile::sndfile

--- a/cmake/FindVorbis.cmake
+++ b/cmake/FindVorbis.cmake
@@ -1,0 +1,133 @@
+# - Find vorbis
+#
+# Provides Vorbis config targets:
+# - Vorbis::vorbis
+# - Vorbis::vorbisenc
+#
+# Find the native vorbis and  vorbisenc includes and libraries
+#
+#  VORBIS_INCLUDE_DIRS - where to find vorbis.h, etc.
+#  VORBIS_LIBRARIES    - List of libraries when using vorbis.
+#  VORBIS_FOUND        - True if vorbis found.
+#
+#  VORBISENC_INCLUDE_DIRS - where to find vorbisenc.h, etc.
+#  VORBISENC_LIBRARIES    - List of libraries when using vorbisenc.
+#  VORBISENC_FOUND        - True if vorbisenc found.
+
+
+find_package(Vorbis CONFIG)
+
+if (NOT TARGET Vorbis::vorbis OR NOT TARGET Vorbis::vorbisenc)
+  if (VORBIS_INCLUDE_DIR)
+	  # Already in cache, be silent
+	  set(VORBIS_FIND_QUIETLY TRUE)
+  endif ()
+
+  if (VORBISENC_INCLUDE_DIR)
+    # Already in cache, be silent
+    set(VORBISENC_FIND_QUIETLY TRUE)
+  endif ()
+
+  find_package(Ogg QUIET)
+
+  find_package(PkgConfig QUIET)
+  pkg_check_modules(PC_VORBIS QUIET vorbis)
+  pkg_check_modules(PC_VORBISENC QUIET vorbisenc)
+
+  set(VORBIS_VERSION ${PC_VORBIS_VERSION})
+
+  find_path(VORBIS_INCLUDE_DIR vorbis/codec.h
+    HINTS
+      ${PC_VORBIS_INCLUDEDIR}
+      ${PC_VORBIS_INCLUDE_DIRS}
+      ${VORBIS_ROOT}
+    )
+
+  find_library(VORBIS_LIBRARY
+    NAMES
+      vorbis
+      vorbis_static
+      libvorbis
+      libvorbis_static
+    HINTS
+      ${PC_VORBIS_LIBDIR}
+      ${PC_VORBIS_LIBRARY_DIRS}
+      ${VORBIS_ROOT}
+    )
+
+  # Handle the QUIETLY and REQUIRED arguments and set VORBIS_FOUND
+  # to TRUE if all listed variables are TRUE.
+  include(FindPackageHandleStandardArgs)
+  find_package_handle_standard_args(Vorbis
+    REQUIRED_VARS
+      VORBIS_LIBRARY
+      VORBIS_INCLUDE_DIR
+      OGG_FOUND
+    VERSION_VAR
+          VORBIS_VERSION
+    )
+
+  if (VORBIS_FOUND)
+    set(VORBIS_INCLUDE_DIRS ${VORBIS_INCLUDE_DIR})
+    set(VORBIS_LIBRARIES ${VORBIS_LIBRARY} ${OGG_LIBRARIES})
+      if (NOT TARGET Vorbis::vorbis)
+      add_library(Vorbis::vorbis UNKNOWN IMPORTED)
+      set_target_properties(Vorbis::vorbis PROPERTIES
+        INTERFACE_INCLUDE_DIRECTORIES "${VORBIS_INCLUDE_DIR}"
+        IMPORTED_LOCATION "${VORBIS_LIBRARY}"
+        INTERFACE_LINK_LIBRARIES Ogg::ogg
+      )
+    endif ()
+  endif ()
+
+  mark_as_advanced(VORBIS_INCLUDE_DIR VORBIS_LIBRARY)
+
+  set(VORBISENC_VERSION ${PC_VORBISENC_VERSION})
+
+  find_path(VORBISENC_INCLUDE_DIR vorbis/vorbisenc.h
+    HINTS
+      ${PC_VORBISENC_INCLUDEDIR}
+      ${PC_VORBISENC_INCLUDE_DIRS}
+      ${VORBISENC_ROOT}
+    )
+
+  find_library(VORBISENC_LIBRARY
+    NAMES
+      vorbisenc
+      vorbisenc_static
+      libvorbisenc
+      libvorbisenc_static
+    HINTS
+      ${PC_VORBISENC_LIBDIR}
+      ${PC_VORBISENC_LIBRARY_DIRS}
+      ${VORBISENC_ROOT}
+    )
+
+  # Handle the QUIETLY and REQUIRED arguments and set VORBISENC_FOUND
+  # to TRUE if all listed variables are TRUE.
+  include(FindPackageHandleStandardArgs)
+  find_package_handle_standard_args(VorbisEnc
+    REQUIRED_VARS
+      VORBISENC_LIBRARY
+      VORBISENC_INCLUDE_DIR
+      VORBIS_FOUND
+    VERSION_VAR
+          VORBISENC_VERSION
+    )
+
+  if (VORBISENC_FOUND)
+    set(VORBISENC_INCLUDE_DIRS ${VORBISENC_INCLUDE_DIR})
+    set(VORBISENC_LIBRARIES ${VORBISENC_LIBRARY} ${VORBIS_LIBRARIES})
+      if (NOT TARGET Vorbis::vorbisenc)
+      add_library(Vorbis::vorbisenc UNKNOWN IMPORTED)
+      set_target_properties(Vorbis::vorbisenc PROPERTIES
+        INTERFACE_INCLUDE_DIRECTORIES "${VORBISENC_INCLUDE_DIR}"
+        IMPORTED_LOCATION "${VORBISENC_LIBRARY}"
+        INTERFACE_LINK_LIBRARIES Vorbis::vorbis
+      )
+    endif ()
+  endif ()
+
+  mark_as_advanced(VORBISENC_INCLUDE_DIR VORBISENC_LIBRARY)
+
+endif() # NOT TARGET Vorbis::vorbis OR NOT TARGET Vorbis::vorbisenc


### PR DESCRIPTION
Fix module dependencies in w2l that aren't transitively included from flashlight.

This is a one-off thing for w2l.