### PR TITLE
Fix some CMake issues

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -65,7 +65,7 @@ jobs:
             git clone https://github.com/facebookresearch/flashlight.git && \
             cd flashlight && pwd && ls && mkdir -p build && cd build && \
             export CC=/usr/bin/gcc-5 && export CXX=/usr/bin/g++-5 && \
-            export MKLROOT=/opt/intel/mkl && export KENLM_ROOT_DIR=/root/kenlm && \
+            export MKLROOT=/opt/intel/mkl && export KENLM_ROOT=/root/kenlm && \
             cmake .. -DFL_BACKEND=CUDA -DFL_BUILD_TESTS=OFF -DFL_BUILD_EXAMPLES=OFF && \
             make -j$(nproc) && make install && \
             cd /wav2letter && mkdir build && cd build && cmake .. && make -j$(nproc)"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,12 +1,16 @@
-cmake_minimum_required(VERSION 3.5.1)
+cmake_minimum_required(VERSION 3.10)
 
-project(wav2letter++)
+project(wav2letter++ CXX C)
 
-# C++ 11 is required
-set(CMAKE_CXX_STANDARD 11)
+# C++ 14 is required
+set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
-find_package(flashlight REQUIRED CONFIG)
+find_package(flashlight CONFIG REQUIRED)
+if (FL_USE_CUDA)
+  enable_language(CUDA)
+endif()
+
 if (NOT TARGET flashlight::flashlight-app-asr)
   message(FATAL_ERROR "flashlight must be build with app/asr for wav2letter++")
 endif ()

--- a/recipes/CMakeLists.txt
+++ b/recipes/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5.1)
+cmake_minimum_required(VERSION 3.10)
 
 # Scripts which are common for our recipes
 add_subdirectory(${CMAKE_CURRENT_LIST_DIR}/utilities/convlm_serializer)

--- a/recipes/local_prior_match/CMakeLists.txt
+++ b/recipes/local_prior_match/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5.1)
+cmake_minimum_required(VERSION 3.10)
 
 project(wav2letter++-recipes-models-local_prior_match)
 
@@ -15,7 +15,7 @@ add_subdirectory(${PROJECT_SOURCE_DIR}/src/runtime) # for target runtime_lpm_oss
 
 target_link_libraries(
   wav2letter++_lpm_oss
-  PUBLIC
+  PRIVATE
   wav2letter++
   runtime_lpm_oss
   module_lpm_oss
@@ -29,7 +29,7 @@ add_executable(
 
 target_include_directories(
   Train_lpm_oss
-  PUBLIC
+  PRIVATE
   ${PROJECT_SOURCE_DIR}/../../..
   )
 
@@ -46,6 +46,6 @@ add_executable(
 
 target_link_libraries(
   decode_len_lpm
-  PUBLIC
+  PRIVATE
   wav2letter++
   )

--- a/recipes/local_prior_match/src/module/CMakeLists.txt
+++ b/recipes/local_prior_match/src/module/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5.1)
+cmake_minimum_required(VERSION 3.10)
 
 add_library(
   module_lpm_oss

--- a/recipes/local_prior_match/src/runtime/CMakeLists.txt
+++ b/recipes/local_prior_match/src/runtime/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5.1)
+cmake_minimum_required(VERSION 3.10)
 
 add_library(
   runtime_lpm_oss

--- a/recipes/self_training/pseudo_labeling/CMakeLists.txt
+++ b/recipes/self_training/pseudo_labeling/CMakeLists.txt
@@ -1,15 +1,15 @@
-cmake_minimum_required(VERSION 3.5.1)
+cmake_minimum_required(VERSION 3.10)
 
 add_executable(analyze_pseudo_label_dataset AnalyzeDataset.cpp)
 
 target_link_libraries(
     analyze_pseudo_label_dataset
-    PUBLIC
+    PRIVATE
     flashlight::flashlight-app-asr
 )
 
 target_include_directories(
     analyze_pseudo_label_dataset
-    PUBLIC
+    PRIVATE
     ${PROJECT_SOURCE_DIR}
 )

--- a/recipes/utilities/convlm_serializer/CMakeLists.txt
+++ b/recipes/utilities/convlm_serializer/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5.1)
+cmake_minimum_required(VERSION 3.10)
 
 add_executable(
     SerializeConvLM
@@ -8,12 +8,12 @@ add_executable(
 
 target_include_directories(
     SerializeConvLM
-    PUBLIC
+    PRIVATE
     ${PROJECT_SOURCE_DIR}
   )
 
 target_link_libraries(
   SerializeConvLM
-  PUBLIC
+  PRIVATE
   flashlight::flashlight-app-asr
   )


### PR DESCRIPTION
Summary:
- Make sure the name of the exported target is `imgclass`, not `imclass`
- Export some variables denoting flashlight backend
- Enable CUDA in example (and wav2letter) builds if fl is built with CUDA
- Bump minimum CMake version in wav2letter
- Bump w2l to C++14

Differential Revision: D25163993

