### PR TITLE
Fixed bug causing "Unknown speaker!" in ami recipe

### DIFF
--- a/data/ami/utils.py
+++ b/data/ami/utils.py
@@ -108,7 +108,7 @@ def get_fid2length(train_file):
 
 def full_records(speakers, fid2length, subset_name=None):
     all_records = []
-    speakers = {(speaker.id, speaker) for speaker in speakers}
+    speakers = {speaker.id: speaker for speaker in speakers}
 
     for fid, length in fid2length:
         speaker = fid.split("_")[2]


### PR DESCRIPTION
**Original Issue**: https://github.com/flashlight/wav2letter/issues/976

closes #[976]

### Summary
`python prepare.py` fails with `AssertionError: Unknown speaker! FEE005`

### Test Plan (required)

Assertion error comes from `utils.py` line 117 `assert speaker in speakers, f"Unknown speaker! {speaker}"`

Judging by the assertion and line 119 `speaker = speakers[speaker]`, the script expects `speakers` to be a dictionary, however, as we can see on line 111 `speakers = {(speaker.id, speaker) for speaker in speakers}`, `speakers` is a set of tuples.

Line 111 should be `speakers = { speaker.id : speaker for speaker in speakers }`, then the script works as intended.
